### PR TITLE
Implement DHCPv6 Server Identifier Generation (#46)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/
 data/
 *.db*
 .vscode/*.log
+server_id

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,6 +583,7 @@ dependencies = [
  "hex",
  "ipnet",
  "phf",
+ "rand",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/example.yaml
+++ b/example.yaml
@@ -192,12 +192,17 @@ networks:
 # responding to INFOREQ.
 v6:
     # optional, interfaces to bind
-    interfaces:
-        - enp6s0
-    # TODO: SERVER ID
-    # server_id:
-    #       type: DUID-LLT (default) | DUID-LL | DUID-EN | ...
-    #       value: ""
+    # interfaces:
+        # - enp6s0
+    # Optional, if server_id is not specified, we will generate an server identifer or use previous generated server identifier(if exists). Addtionally, if all settings are the same as previous settings, we will also use previous generated server identifier.
+    server_id:
+        type: LLT # LLT (default) | LL | EN | UUID
+        identifier: fe80::c981:b769:461a:bfb4 # Optional, set blank or remove to auto-generate link-layer address. For LLT and LL, it must be a valid link-layer address.
+        time: 1111112 # Optional, set blank or remove to auto-generate time. For LLT, it must be a valid u32 timestamp
+        hardware_type: 1 # Optional, set blank or remove to auto-generate hardware type. For LL, it must be a valid u16 hardware type
+        #enterprise_id: 1 # Optional, set blank or remove to auto-generate enterprise id. For EN, it must be a valid u32 enterprise id
+        persist: true # Optional, default value is true. set false to generate a new DUID every time the server is restarted.
+        path: ./server_id # optional. default is /var/lib/dora/server_id
     # global options (optional)
     options:
         values:
@@ -222,7 +227,7 @@ v6:
         2001:db8:1::/64: # https://en.wikipedia.org/wiki/IPv6_address#Documentation
             # optional - what interfaces we will apply to this network
             interfaces:
-                - enp6s0
+                # - enp6s0
             # no explicit ranges (yet)
             config:
                 lease_time:

--- a/libs/config/Cargo.toml
+++ b/libs/config/Cargo.toml
@@ -17,6 +17,7 @@ trust-dns-proto = { workspace = true }
 base64 = "0.21.0"
 hex = "0.4"
 phf = { version = "0.11", features = ["macros"] }
+rand = "0.8"
 
 dora-core = { path = "../../dora-core" }
 client-classification = { path = "../client-classification" }

--- a/libs/config/sample/config_v6.yaml
+++ b/libs/config/sample/config_v6.yaml
@@ -1,0 +1,29 @@
+v6:
+    server_id:
+        type: LLT
+        identifier: fe80::c981:b769:461a:bfb4
+        time: 1111112
+        hardware_type: 1
+        persist: true
+        path: ./server_id
+    options:
+        values:
+            23:
+                type: ip_list
+                value:
+                    - 2001:db8::1
+                    - 2001:db8::2
+    networks:
+        2001:db8:1::/64:
+            config:
+                lease_time:
+                    default: 3600
+                preferred_time:
+                    default: 3600
+            options:
+                values:
+                    23:
+                        type: ip_list
+                        value:
+                            - 2001:db8::1
+                            - 2001:db8::2

--- a/libs/config/sample/config_v6_EN.yaml
+++ b/libs/config/sample/config_v6_EN.yaml
@@ -1,0 +1,28 @@
+v6:
+    server_id:
+        type: EN
+        identifier: 1122FFFE3842
+        enterprise_id: 23
+        persist: true
+        path: ./server_id
+    options:
+        values:
+            23:
+                type: ip_list
+                value:
+                    - 2001:db8::1
+                    - 2001:db8::2
+    networks:
+        2001:db8:1::/64:
+            config:
+                lease_time:
+                    default: 3600
+                preferred_time:
+                    default: 3600
+            options:
+                values:
+                    23:
+                        type: ip_list
+                        value:
+                            - 2001:db8::1
+                            - 2001:db8::2

--- a/libs/config/sample/config_v6_LL.yaml
+++ b/libs/config/sample/config_v6_LL.yaml
@@ -1,0 +1,28 @@
+v6:
+    server_id:
+        type: LL
+        identifier: fe80::c981:b769:461a:bfb4
+        hardware_type: 2
+        persist: true
+        path: ./server_id
+    options:
+        values:
+            23:
+                type: ip_list
+                value:
+                    - 2001:db8::1
+                    - 2001:db8::2
+    networks:
+        2001:db8:1::/64:
+            config:
+                lease_time:
+                    default: 3600
+                preferred_time:
+                    default: 3600
+            options:
+                values:
+                    23:
+                        type: ip_list
+                        value:
+                            - 2001:db8::1
+                            - 2001:db8::2

--- a/libs/config/sample/config_v6_UUID.yaml
+++ b/libs/config/sample/config_v6_UUID.yaml
@@ -1,0 +1,27 @@
+v6:
+    server_id:
+        type: UUID
+        identifier: 451c810bf191a92abf3768dd1ed61f3a
+        persist: true
+        path: ./server_id
+    options:
+        values:
+            23:
+                type: ip_list
+                value:
+                    - 2001:db8::1
+                    - 2001:db8::2
+    networks:
+        2001:db8:1::/64:
+            config:
+                lease_time:
+                    default: 3600
+                preferred_time:
+                    default: 3600
+            options:
+                values:
+                    23:
+                        type: ip_list
+                        value:
+                            - 2001:db8::1
+                            - 2001:db8::2

--- a/libs/config/sample/config_v6_no_persist.yaml
+++ b/libs/config/sample/config_v6_no_persist.yaml
@@ -1,0 +1,25 @@
+v6:
+    server_id:
+        type: LLT
+        persist: false
+    options:
+        values:
+            23:
+                type: ip_list
+                value:
+                    - 2001:db8::1
+                    - 2001:db8::2
+    networks:
+        2001:db8:1::/64:
+            config:
+                lease_time:
+                    default: 3600
+                preferred_time:
+                    default: 3600
+            options:
+                values:
+                    23:
+                        type: ip_list
+                        value:
+                            - 2001:db8::1
+                            - 2001:db8::2

--- a/libs/config/src/v4.rs
+++ b/libs/config/src/v4.rs
@@ -666,6 +666,7 @@ impl FloodThreshold {
 
 #[cfg(test)]
 mod tests {
+
     use dora_core::dhcproto::v4;
 
     use super::*;

--- a/libs/config/src/v6.rs
+++ b/libs/config/src/v6.rs
@@ -1,6 +1,9 @@
+use hex;
 use std::{
     collections::HashMap,
     net::Ipv6Addr,
+    path::Path,
+    str::FromStr,
     time::{Duration, SystemTime},
 };
 
@@ -17,8 +20,13 @@ use dora_core::{
 use ipnet::Ipv6Net;
 use tracing::debug;
 
-use crate::{wire, LeaseTime};
-
+use crate::{
+    generate_random_bytes,
+    wire::{self, v6::ServerDuidInfo},
+    LeaseTime, PersistIdentifier,
+};
+/// the default path to  server identifier file path
+pub static DEFAULT_SERVER_ID_FILE_PATH: &str = "/var/lib/dora/server_id";
 // const DEFAULT_VALID: Duration = Duration::from_secs(12 * 24 * 60 * 60); // 12 days
 // const DEFAULT_PREFERRED: Duration = Duration::from_secs(8 * 24 * 60 * 60); // 8 days
 
@@ -176,38 +184,150 @@ pub const fn is_unicast_link_local(ip: &Ipv6Addr) -> bool {
     (ip.segments()[0] & 0xffc0) == 0xfe80
 }
 
+pub fn generate_duid_from_config(server_id: &ServerDuidInfo, link_layer: Ipv6Addr) -> Result<Duid> {
+    fn parse_id(id: &str, link_layer: Ipv6Addr) -> Result<Ipv6Addr> {
+        Ok(if id.is_empty() {
+            link_layer
+        } else {
+            Ipv6Addr::from_str(id).context("identifier must be a valid ipv6 address")?
+        })
+    }
+    fn parse_htype(htype: u16) -> HType {
+        if htype == 0 {
+            HType::Eth
+        } else {
+            //TODO: This is a compromise of v4 HType. Should be changed to v6 HType after dhcproto is updated.
+            HType::from(htype as u8)
+        }
+    }
+    match server_id {
+        ServerDuidInfo::LLT {
+            htype,
+            identifier,
+            time,
+        } => {
+            let htype = parse_htype(*htype);
+            let identifier = parse_id(identifier, link_layer)?;
+            let time = if *time == 0 {
+                SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .context("unable to get system time")?
+                    .as_secs() as u32
+            } else {
+                *time
+            };
+            Ok(Duid::link_layer_time(htype, time, identifier))
+        }
+        ServerDuidInfo::LL { htype, identifier } => {
+            let htype = parse_htype(*htype);
+            let identifier = parse_id(identifier, link_layer)?;
+            Ok(Duid::link_layer(htype, identifier))
+        }
+        ServerDuidInfo::EN {
+            enterprise_id,
+            identifier,
+        } => {
+            let enterprise_id = if *enterprise_id == 0 {
+                1 //TODO: harewire to 1 temporarily
+            } else {
+                *enterprise_id
+            };
+            let identifier = if identifier.is_empty() {
+                generate_random_bytes(6)
+            } else {
+                hex::decode(identifier).context("identifier should be a valid hex string")?
+            };
+            Ok(Duid::enterprise(enterprise_id, &identifier[..]))
+        }
+        ServerDuidInfo::UUID { identifier } => {
+            if identifier.is_empty() {
+                bail!("identifier must be specified for UUID type DUID");
+            }
+            let identifier =
+                hex::decode(identifier).context("identifier should be a valid hex string")?;
+            Ok(Duid::uuid(&identifier[..]))
+        }
+    }
+}
+
+fn generate_duid_and_persist(
+    server_id_info: &ServerDuidInfo,
+    link_layer_address: Ipv6Addr,
+    server_id_path: &Path,
+) -> Result<Duid> {
+    let duid = generate_duid_from_config(server_id_info, link_layer_address)
+        .context("can not generate duid from config")?;
+    PersistIdentifier {
+        identifier: hex::encode(duid.as_ref()),
+        duid_config: server_id_info.clone(),
+    }
+    .to_json(server_id_path)
+    .context("can not write server identifier json")?;
+    Ok(duid)
+}
+
 impl TryFrom<wire::v6::Config> for Config {
     type Error = anyhow::Error;
 
     fn try_from(cfg: wire::v6::Config) -> Result<Self> {
         let interfaces = crate::v6_find_interfaces(cfg.interfaces)?;
         // DUID-LLT is the default, will need config options to do others
-        let int = interfaces
-            .first()
-            .context("must find at least one v6 interface")?;
-
-        // find a link local ipv6 address, then convert that into a Duid
-        let server_id = int
-            .ips
+        let link_local = interfaces
             .iter()
-            .find_map(|ip| match ip {
-                IpNetwork::V6(ip) if is_unicast_link_local(&ip.ip()) => Some(*ip),
-                _ => None,
+            .find_map(|int| {
+                int.ips.iter().find_map(|ip| match ip {
+                    IpNetwork::V6(ip) if is_unicast_link_local(&ip.ip()) => Some(*ip),
+                    _ => None,
+                })
             })
-            .context("unable to find a link local ip")
-            .and_then(|link_local| {
-                // https://www.rfc-editor.org/rfc/rfc8415#section-11.2
-                Ok(Duid::link_layer_time(
-                    // TODO: hardcoded eth type right now
-                    HType::Eth,
-                    SystemTime::now()
-                        .duration_since(SystemTime::UNIX_EPOCH)
-                        .context("unable to get system time")?
-                        .as_secs() as u32,
-                    link_local.ip(),
-                ))
-            })?;
-
+            .context("unable to find a link local ip")?;
+        let server_id = match cfg.server_id {
+            None => {
+                // if server id file exists, then use it
+                let server_id_path = Path::new(DEFAULT_SERVER_ID_FILE_PATH);
+                if server_id_path.exists() {
+                    let identifier_file = PersistIdentifier::from_json(server_id_path)
+                        .context("can not read server identifier json")?;
+                    identifier_file
+                        .duid()
+                        .context("can not get duid from server identifier file")?
+                } else {
+                    // https://www.rfc-editor.org/rfc/rfc8415#section-11.2
+                    Duid::link_layer_time(
+                        HType::Eth,
+                        SystemTime::now()
+                            .duration_since(SystemTime::UNIX_EPOCH)
+                            .context("unable to get system time")?
+                            .as_secs() as u32,
+                        link_local.ip(),
+                    )
+                }
+            }
+            Some(server_id) => {
+                let server_id_path = if server_id.path.is_empty() {
+                    Path::new(DEFAULT_SERVER_ID_FILE_PATH)
+                } else {
+                    Path::new(&server_id.path)
+                };
+                if !server_id.persist {
+                    generate_duid_from_config(&server_id.info, link_local.ip())
+                        .context("can not generate duid from config")?
+                } else if !server_id_path.exists() {
+                    generate_duid_and_persist(&server_id.info, link_local.ip(), server_id_path)?
+                } else {
+                    let identifier_file = PersistIdentifier::from_json(server_id_path)
+                        .context("can not read server identifier json")?;
+                    if identifier_file.duid_config == server_id.info {
+                        // Here, server_id.info is read from a YAML file and the fields like time, identifier, enterprise_id, etc. have not been processed yet (i.e., 0 has not been replaced with the corresponding default values). Therefore, a comparison can be made. For example, if the server_id type is set to LLT and all other values are empty, then both the persisted file and server_id.info will have all fields as 0 or empty string, making them equal. The difference in time or local link layer address due to changes in time or adapter will not affect the comparison.
+                        identifier_file
+                            .duid()
+                            .context("can not get duid from server identifier file")?
+                    } else {
+                        generate_duid_and_persist(&server_id.info, link_local.ip(), server_id_path)?
+                    }
+                }
+            }
+        };
         let global_opts = cfg.options;
         debug!(?interfaces, ?server_id, "v6 interfaces that will be used");
         let networks = cfg
@@ -277,5 +397,83 @@ impl TryFrom<wire::v6::Config> for Config {
             opts: global_opts.map(|o| o.get()),
             server_id,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{v4::Config, PersistIdentifier};
+    use std::path::Path;
+
+    pub static TEST_SERVER_ID_FILE_PATH: &str = "./server_id"; //can not use include_str because sometimes it doesn't exist.
+    pub static CONFIG_V6_YAML: &str = include_str!("../sample/config_v6.yaml");
+    pub static CONFIG_V6_LL_YAML: &str = include_str!("../sample/config_v6_LL.yaml");
+    pub static CONFIG_V6_EN_YAML: &str = include_str!("../sample/config_v6_EN.yaml");
+    pub static CONFIG_V6_UUID_YAML: &str = include_str!("../sample/config_v6_UUID.yaml");
+    pub static CONFIG_V6_NO_PERSIST_YAML: &str =
+        include_str!("../sample/config_v6_no_persist.yaml");
+
+    /// test if v6_config can generate a server_id; and if it can dump it to a file
+    #[test]
+    fn test_v6_config() {
+        let path = Path::new(TEST_SERVER_ID_FILE_PATH);
+        if path.exists() {
+            std::fs::remove_file(path).unwrap();
+        }
+
+        let cfg = Config::new(CONFIG_V6_YAML).unwrap();
+        // test a range decoded properly
+        match cfg.v6() {
+            Some(v6_config) => {
+                println!("{:?}", v6_config);
+            }
+            None => {
+                panic!("expected v6 config")
+            }
+        };
+
+        let identifier_file = PersistIdentifier::from_json(path).unwrap();
+        let file_server_id = identifier_file.duid().unwrap();
+        let file_server_id = file_server_id.as_ref();
+        let server_id = cfg.v6().unwrap().server_id();
+        assert_eq!(server_id, file_server_id);
+    }
+
+    /// test if we can generate a different server_id using different config rather than using the config file that exists
+    #[test]
+    fn test_v6_generate_different_server_id() {
+        let cfg1 = Config::new(CONFIG_V6_YAML).unwrap();
+        let cfg2 = Config::new(CONFIG_V6_LL_YAML).unwrap();
+        let server_id1 = cfg1.v6().unwrap().server_id();
+        let server_id2 = cfg2.v6().unwrap().server_id();
+        println!("server_id1: {:?}", server_id1);
+        println!("server_id2: {:?}", server_id2);
+        assert_ne!(server_id1, server_id2);
+    }
+    /// test if we can generate EN type server_id
+    #[test]
+    fn test_v6_generate_en_server_id() {
+        let cfg = Config::new(CONFIG_V6_EN_YAML).unwrap();
+        let server_id = cfg.v6().unwrap().server_id();
+        println!("server_id: {:?}", server_id);
+    }
+    /// test if we can generate UUID type server_id
+    #[test]
+    fn test_v6_generate_uuid_server_id() {
+        let cfg = Config::new(CONFIG_V6_UUID_YAML).unwrap();
+        let server_id = cfg.v6().unwrap().server_id();
+        println!("server_id: {:?}", server_id);
+    }
+    /// test if wen can generate server_id without persisting it to a file
+    #[test]
+    fn test_v6_generate_server_id_without_persist() {
+        let server_id_path = Path::new(TEST_SERVER_ID_FILE_PATH);
+        if server_id_path.exists() {
+            std::fs::remove_file(server_id_path).unwrap();
+        }
+        let cfg = Config::new(CONFIG_V6_NO_PERSIST_YAML).unwrap();
+        let server_id = cfg.v6().unwrap().server_id();
+        println!("server_id: {:?}", server_id);
+        assert!(!server_id_path.exists());
     }
 }


### PR DESCRIPTION
* Implement server_id generation for DHCPv6

* fmt some files

* some change based on clippy

* delete comment in test config v6 yamls

* remove redudant bytes to string. use hex crate instead.

* Refactor serverId config

* Still constructing. not finished yet

* modify position of v6 tests.

* minor change

* modify DHCPv6 test config path

* Add server_id to .gitignore

* minor change

* del defaultPersistIdentifier to avoid confusion

* remove redundant

* add a comment to better explain persist logic

* update to better test

* minor change

* add todo tag for v6 htype

* ipv6: refactor duid parsing

---------